### PR TITLE
#27 - Disabling Tweet button when 0 or over 60 characters are provided

### DIFF
--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -102,6 +102,8 @@ exports[`Twitter renders without crashing 1`] = `
         <button
           class="new-tweet-button"
           data-testid="new-tweet-button"
+          disabled=""
+          title="You need at least one character to proceed"
           type="button"
         >
           Tweet
@@ -133,7 +135,7 @@ exports[`Twitter renders without crashing 1`] = `
               <h6
                 class="tweet-date"
               >
-                Nov 20
+                NOV 20
               </h6>
             </div>
           </div>
@@ -182,7 +184,7 @@ exports[`Twitter renders without crashing 1`] = `
               <h6
                 class="tweet-date"
               >
-                Nov 22
+                NOV 22
               </h6>
             </div>
           </div>
@@ -231,7 +233,7 @@ exports[`Twitter renders without crashing 1`] = `
               <h6
                 class="tweet-date"
               >
-                Nov 25
+                NOV 25
               </h6>
             </div>
           </div>
@@ -280,7 +282,7 @@ exports[`Twitter renders without crashing 1`] = `
               <h6
                 class="tweet-date"
               >
-                Nov 26
+                NOV 26
               </h6>
             </div>
           </div>
@@ -329,7 +331,7 @@ exports[`Twitter renders without crashing 1`] = `
               <h6
                 class="tweet-date"
               >
-                Nov 30
+                NOV 30
               </h6>
             </div>
           </div>
@@ -651,39 +653,6 @@ exports[`Twitter renders without crashing 1`] = `
         </div>
       </div>
     </div>
-  </div>
-</div>
-`;
-
-exports[`renders without crashing 1`] = `
-<div>
-  <div
-    class="App"
-  >
-    <header
-      class="App-header"
-    >
-      <img
-        alt="logo"
-        class="App-logo"
-        src="[object Object]"
-      />
-      <p>
-        Edit 
-        <code>
-          src/App.js
-        </code>
-         and save to reload.
-      </p>
-      <a
-        class="App-link"
-        href="https://reactjs.org"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Learn React
-      </a>
-    </header>
   </div>
 </div>
 `;

--- a/src/components/NewTweet.jsx
+++ b/src/components/NewTweet.jsx
@@ -5,10 +5,23 @@ import { addTweet as addTweetAction } from '../actions';
 import Avatar from './Avatar';
 import { isEmpty } from '../utils';
 
-// const MAX_CHARS = 60; // TODO: Implement max for input
+const MAX_CHARS = 60;
 
 export class NewTweet extends Component {
-  state = { text: '' }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: '',
+      addTweetButtonDisabled: true,
+    };
+    this.onTweetInputChange = this.onTweetInputChange.bind(this);
+    this.getMaxCharsAllowed = this.getMaxCharsAllowed.bind(this);
+  }
+
+  getMaxCharsAllowed() {
+    return this.props.maxChars ? this.props.maxChars : MAX_CHARS;
+  }
 
   publishTweet() {
     const { user, addTweet } = this.props;
@@ -20,6 +33,15 @@ export class NewTweet extends Component {
       date: new Date(),
       retweets: 0,
     });
+  }
+
+  onTweetInputChange(event) {
+    
+    const { value: text } = event.target;
+
+    const addTweetButtonDisabled = text.length === 0 || text.length > this.getMaxCharsAllowed();
+
+    this.setState({ text, addTweetButtonDisabled });
   }
 
   render() {
@@ -34,13 +56,15 @@ export class NewTweet extends Component {
           className="new-tweet-input"
           placeholder="What's happening?"
           data-testid="new-tweet-input"
-          onChange={({ target: { value } }) => this.setState({ text: value })}
+          onChange={this.onTweetInputChange}
         />
         <button
           className="new-tweet-button"
           type="button"
           data-testid="new-tweet-button"
           onClick={this.publishTweet}
+          disabled={this.state.addTweetButtonDisabled}
+          title={this.state.addTweetButtonDisabled ? `You need at least one character to proceed` : ''}
         >
           Tweet
         </button>

--- a/src/components/NewTweet.test.js
+++ b/src/components/NewTweet.test.js
@@ -1,16 +1,55 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, within } from '@testing-library/react';
 import { NewTweet } from './NewTweet';
+
+const user = {
+  id: 1,
+  name: 'Jeremy',
+  avatar: { src: '/avatar' }
+}
+
+const addTweet = () => {
+  console.log('Adding Tweet')
+}
 
 describe('New tweet', () => {
   test('it renders correctly', () => {
-    const { container } = render(<NewTweet />);
+    const { container } = render(<NewTweet user={user} addTweet={addTweet} />);
     expect(container).toMatchSnapshot();
   });
-  test.skip('Enforce max lenght for tweet', () => {
-    const { container, getByTestId } = render(<NewTweet />);
-    const input = getByTestId('new-tweet-input');
+  
+  test('Enforce max length for tweet by using the maxChars prop to 30 chars', () => {
+    const { container, getByTestId } = render(<NewTweet maxChars={30} user={user} addTweet={addTweet} />);
+    
+    const input = within(container).getByTestId('new-tweet-input');
     const button = getByTestId('new-tweet-button');
-    // TODO: Try to type more than max number of chars and validate the result
+
+    fireEvent.change(input, { target: {value: 'This is my first tweet with more than 30 chars'}});
+
+    expect(button).toHaveProperty('disabled', true);
+
+    fireEvent.change(input, { target: {value: 'Less than 30 chars'}});
+
+    expect(button).toHaveProperty('disabled', false);
+
   });
+
+  test("Enforce max length for tweet, using default value", () => {
+
+    const { container, getByTestId } = render(<NewTweet user={user} addTweet={addTweet} />);
+    
+    const input = within(container).getByTestId('new-tweet-input');
+
+    const button = getByTestId('new-tweet-button');
+
+    fireEvent.change(input, { target: {value: 'This is my first tweet with more than 60 chars. This is my first tweet with more than 60 chars.'}});
+
+    expect(button).toHaveProperty('disabled', true);
+
+    fireEvent.change(input, { target: {value: 'Less than 60 chars'}});
+
+    expect(button).toHaveProperty('disabled', false);
+
+  });
+
 });

--- a/src/components/NewTweet.test.js
+++ b/src/components/NewTweet.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, within } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { NewTweet } from './NewTweet';
 
 const user = {
@@ -19,9 +19,9 @@ describe('New tweet', () => {
   });
   
   test('Enforce max length for tweet by using the maxChars prop to 30 chars', () => {
-    const { container, getByTestId } = render(<NewTweet maxChars={30} user={user} addTweet={addTweet} />);
+    const { getByTestId } = render(<NewTweet maxChars={30} user={user} addTweet={addTweet} />);
     
-    const input = within(container).getByTestId('new-tweet-input');
+    const input = getByTestId('new-tweet-input');
     const button = getByTestId('new-tweet-button');
 
     fireEvent.change(input, { target: {value: 'This is my first tweet with more than 30 chars'}});
@@ -36,9 +36,9 @@ describe('New tweet', () => {
 
   test("Enforce max length for tweet, using default value", () => {
 
-    const { container, getByTestId } = render(<NewTweet user={user} addTweet={addTweet} />);
+    const { getByTestId } = render(<NewTweet user={user} addTweet={addTweet} />);
     
-    const input = within(container).getByTestId('new-tweet-input');
+    const input = getByTestId('new-tweet-input');
 
     const button = getByTestId('new-tweet-button');
 

--- a/src/components/__snapshots__/NewTweet.test.js.snap
+++ b/src/components/__snapshots__/NewTweet.test.js.snap
@@ -1,3 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`New tweet it renders correctly 1`] = `<div />`;
+exports[`New tweet it renders correctly 1`] = `
+<div>
+  <div
+    class="new-tweet"
+  >
+    <img
+      alt="avatar"
+      class="avatar"
+      src="[object Object]"
+    />
+    <input
+      class="new-tweet-input"
+      data-testid="new-tweet-input"
+      placeholder="What's happening?"
+    />
+    <button
+      class="new-tweet-button"
+      data-testid="new-tweet-button"
+      disabled=""
+      title="You need at least one character to proceed"
+      type="button"
+    >
+      Tweet
+    </button>
+  </div>
+</div>
+`;


### PR DESCRIPTION
#27 - Disabling Tweet button when 0 or over 60 (default, but it's configurable) characters are provided.
The NewTweet has a default MAX_CHARSof 60, but you can pass maxChars props to configure it to less or more.
If you pass the maxChars prop, the default MAX_CHARS in NewTweet will be overridden and maxChars will be used.