### PR TITLE
Persist the pending tweet on local storage

### DIFF
--- a/src/components/NewTweet.jsx
+++ b/src/components/NewTweet.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { addTweet as addTweetAction } from '../actions';
@@ -7,12 +7,27 @@ import { isEmpty } from '../utils';
 
 // const MAX_CHARS = 60; // TODO: Implement max for input
 
-export class NewTweet extends Component {
-  state = { text: '' }
+// TODO move this hook out of this file
+const useStoredValue = (key) => {
+  const [text, setText] = useState('');
 
-  publishTweet() {
-    const { user, addTweet } = this.props;
-    const { text } = this.state;
+  useEffect(() => {
+    const storedText = window.localStorage.getItem(key);
+    setText(storedText);
+  }, [key]);
+
+  const handleTextChanged = (passedText) => {
+    setText(passedText);
+    window.localStorage.setItem(key, passedText);
+  };
+
+  return [text, handleTextChanged];
+};
+
+export const NewTweet = ({ user, addTweet }) => {
+  const [text, setText] = useStoredValue('pendingTweet');
+
+  const handlePublishTweet = () => {
     addTweet({
       content: text,
       userId: user.id,
@@ -20,34 +35,38 @@ export class NewTweet extends Component {
       date: new Date(),
       retweets: 0,
     });
+    setText('');
+  };
+
+  const handleInputChanged = ({ target: { value } }) => {
+    setText(value);
+  };
+
+  if (!user || isEmpty(user)) {
+    return null;
   }
 
-  render() {
-    const { user } = this.props;
-    if (!user || isEmpty(user)) {
-      return null;
-    }
-    return (
-      <div className="new-tweet">
-        <Avatar src={user.avatar} />
-        <input
-          className="new-tweet-input"
-          placeholder="What's happening?"
-          data-testid="new-tweet-input"
-          onChange={({ target: { value } }) => this.setState({ text: value })}
-        />
-        <button
-          className="new-tweet-button"
-          type="button"
-          data-testid="new-tweet-button"
-          onClick={this.publishTweet}
-        >
-          Tweet
-        </button>
-      </div>
-    );
-  }
-}
+  return (
+    <div className="new-tweet">
+      <Avatar src={user.avatar} />
+      <input
+        className="new-tweet-input"
+        placeholder="What's happening?"
+        data-testid="new-tweet-input"
+        onChange={handleInputChanged}
+        value={text}
+      />
+      <button
+        className="new-tweet-button"
+        type="button"
+        data-testid="new-tweet-button"
+        onClick={handlePublishTweet}
+      >
+        Tweet
+      </button>
+    </div>
+  );
+};
 
 NewTweet.propTypes = {
   user: PropTypes.object.isRequired,


### PR DESCRIPTION
It includes:
- `NewTweet` component was migrated to a functional component
- `useStoredValue` hook, it stores values on the local storage, each value can be configured using its own key

What's pending:
- it will be good to move the `useStoredValue` hook to its own file


fixes #43 